### PR TITLE
Deploy to multiple servers

### DIFF
--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -6,18 +6,22 @@ clc          = require "cli-color"
 ####
 ### Send commands to server ###
 ####
-exports.deploy = (config) ->
-  dir = config["server_dir"]
-  server = config["server"]
-  config["history_releases_count"] = 2 if config["history_releases_count"] && config["history_releases_count"] < 2
-  if server instanceof String
-    initDeploy server, config
-  if server instanceof Array
-    initDeploy s, config for s in server
 
-initDeploy = (config) ->
+exports.deploy = (config) ->
+  xtermColor = 13
+  server = config["server"]
+  if typeof server == "string"
+    initDeploy server, config, clc.xterm(xtermColor).bold
+  else if server instanceof Array
+    for s in server
+      initDeploy s, config, clc.xterm(xtermColor).bold
+      xtermColor += 1
+
+initDeploy = (server, config, color) ->
+  dir = config["server_dir"]
+  config["history_releases_count"] = 2 if config["history_releases_count"] && config["history_releases_count"] < 2
   # Open connection to server
-  p = spawn "ssh", [config["server"], "bash -s"], stdio: ["pipe", 1, 2]
+  p = spawn "ssh", [server, "bash -s"], stdio: ["pipe", 1, 2]
 
   # Write script directly to SSH's STDIN
   bs = new BashScript p.stdin
@@ -30,13 +34,13 @@ initDeploy = (config) ->
         @cmd "rm", "-rf", release_dir
 
     ### Basic setup ###
-    @log "Create subdirs"
+    @log server + " Create subdirs", color
 
     for subdir in ["shared", "releases", "tmp"]
       @mkdir dir, subdir
 
     # Create shared dirs
-    @log "Create shared dirs"
+    @log server + " Create shared dirs", color
 
     for shared_dir in config["shared_dirs"]
       @mkdir dir, "shared", shared_dir
@@ -45,7 +49,7 @@ initDeploy = (config) ->
     @cd dir
 
     ### Fetch code ###
-    @log "Fetch code"
+    @log server + " Fetch code", color
 
     # Check if need remove all git dir first
     if config["force_regenerate_git_dir"]
@@ -67,7 +71,7 @@ initDeploy = (config) ->
     @cmd "git", "pull"
 
     # Copy code to release dir
-    @log "Copy code to release dir"
+    @log server + " Copy code to release dir", color
     # Compute version number
     @raw 'rno="$(readlink "' + (path.join dir, "current") + '")"'
     @raw 'rno="$(basename "$rno")"'
@@ -75,7 +79,7 @@ initDeploy = (config) ->
     @cmd "cp", "-r", (path.join dir, "tmp", "scm", config["prj_git_relative_dir"] || ""), (path.join dir, "releases", "$rno")
 
     ### Link shared dirs ###
-    @log "Link shared dirs"
+    @log server + " Link shared dirs"
 
     @cd dir, "releases", "$rno"
     for shared_dir in config["shared_dirs"]
@@ -84,16 +88,16 @@ initDeploy = (config) ->
       @cmd "ln", "-s", (path.join dir, "shared", shared_dir), shared_dir
 
     ### Run pre-start scripts ###
-    @log "Run pre-start scripts"
+    @log server + " Run pre-start scripts", color
     for cmd in config["prerun"]
       @raw_cmd cmd
 
     ### Start the service ###
-    @log "Start service"
+    @log server + " Start service", color
     @raw_cmd config["run_cmd"]
 
     ### Update current link ###
-    @log "Update current link"
+    @log server + " Update current link", color
 
     @cd dir
     @if_link_exists "current", ->
@@ -101,7 +105,7 @@ initDeploy = (config) ->
     @cmd "ln", "-s", "releases/$rno", "current"
 
     ### Clean the release dir ###
-    @log "Cleaning release dir"
+    @log server + " Cleaning release dir", color
 
     @cd dir, "releases"
     @assign_output "release_dirs",


### PR DESCRIPTION
Hello!

I had emailed about this earlier. This change will allow your tool to deploy to multiple servers by specifying an array in the deploy.json instead of a string. When it logs it will tell you the server name, and each server gets a different color.

I tested this out locally and it seems to work fine.
